### PR TITLE
Update third parties only yearly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
             "groupName": "all dependencies",
             "groupSlug": "all",
             "packagePatterns": ["*"],
-            "schedule": ["every 3 months on the first day of the month"]
+            "schedule": ["on the first day of the year"]
         },
         {
             "groupName": "internal dependencies",


### PR DESCRIPTION
We still get a lot more renovate PRs for third party modules than I think we want or need.

I'm gonna propose we only update them at the start of each new year, and see who objects =)

Renovate documentation says:

> Technical details: We mostly rely on the text parsing of the library later but only its concepts of "days", "time_before", and "time_after" (Renovate does not support scheduled minutes or "at an exact time" granularity).

(https://docs.renovatebot.com/configuration-options/#schedule)

So I tested this syntax using [this later.js syntax checker](https://codepen.io/antonlydike/full/KgygpA)