### PR TITLE
Automerge patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,10 @@
         },
         {
             "matchUpdateTypes": ["patch", "pin", "digest"],
-            "automerge": true
+            "automerge": true,
+            "excludePackagePatterns": [
+                "^vanilla-framework"
+            ]
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
     "extends": [
-        ":automergeDisabled",
         ":autodetectPinVersions",
         ":combinePatchMinorReleases",
         ":separateMajorReleases",
@@ -33,6 +32,10 @@
         {
             "depTypeList": ["devDependencies"],
             "extends": [":automergeMinor"]
+        },
+        {
+            "matchUpdateTypes": ["patch", "pin", "digest"],
+            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
## Done
Update Renovate config to auto-merge patch releases
Exclude Vanilla from auto-merging

Docs used to make this change: https://docs.renovatebot.com/configuration-options/#automerge

## QA
This change has been applied here https://github.com/canonical-web-and-design/dqlite.io/pull/135. Once the renovate actions work as expected there is will be ready to merge.