### PR TITLE
Revert the addition of engines as it's invalid

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,8 +37,3 @@
     ],
   "dependencyDashboard": false
 }
-{
-  "engines": {
-    "node": "^16.13.0"
-  }
-}


### PR DESCRIPTION
According to https://docs.renovatebot.com/node/ this needs to be defined on a per-project level in that projects package.json.