### PR TITLE
remove separateMultipleMajorReleases preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
         ":autodetectPinVersions",
         ":combinePatchMinorReleases",
         ":separateMajorReleases",
-        ":separateMultipleMajorReleases",
         ":ignoreModulesAndTests",
         ":ignoreUnstable",
         ":prImmediately",


### PR DESCRIPTION
Removed the `separateMultipleMajorReleases` (see [renovate config docs](https://docs.renovatebot.com/presets-default/#separatemultiplemajorreleases)) preset config in an effort to reduce the number of individual PRs we have open for different versions of the same dependency, i.e.
![Screenshot from 2022-01-04 10-45-28](https://user-images.githubusercontent.com/2376968/148047723-0d5c2e03-f7b6-44eb-97a2-386eb7382b80.png)

